### PR TITLE
Fix A/B tested thumbnails not updating

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -66,7 +66,7 @@ function setupThumbnailRedirectListeners(preferredThumbnailFile) {
                         }
                     },
                     "condition": {
-                        "regexFilter": "^https://i.ytimg.com/(vi|vi_webp)/(.*)/(default|hqdefault|mqdefault|sddefault|hq720).jpg(.*)",
+                        "regexFilter": "^https://i.ytimg.com/(vi|vi_webp)/(.*)/(default|hqdefault|mqdefault|sddefault|hq720|hq720_custom_[0-9]+).jpg(.*)",
                         "resourceTypes": [
                             "image"
                         ]

--- a/js/background.js
+++ b/js/background.js
@@ -62,11 +62,11 @@ function setupThumbnailRedirectListeners(preferredThumbnailFile) {
                     "action": {
                         "type": "redirect",
                         "redirect": {
-                            "regexSubstitution": `https://i.ytimg.com/\\1/\\2/${preferredThumbnailFile}.jpg\\4`
+                            "regexSubstitution": `https://i.ytimg.com/\\1/\\2/${preferredThumbnailFile}.jpg\\5`
                         }
                     },
                     "condition": {
-                        "regexFilter": "^https://i.ytimg.com/(vi|vi_webp)/(.*)/(default|hqdefault|mqdefault|sddefault|hq720|hq720_custom_[0-9]+).jpg(.*)",
+                        "regexFilter": "^https://i.ytimg.com/(vi|vi_webp)/(.*)/(default|hqdefault|mqdefault|sddefault|hq720)(_custom_[0-9]+)?.jpg(.*)",
                         "resourceTypes": [
                             "image"
                         ]

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -104,9 +104,9 @@ if (typeof window.styleElement === 'undefined') { // shitty way to detect if scr
         let imgElements = document.getElementsByTagName('img');
 
         for (let i = 0; i < imgElements.length; i++) {
-            if (imgElements[i].src.match('https://i.ytimg.com/vi/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg?.*')) {
+            if (imgElements[i].src.match('https://i.ytimg.com/(vi|vi_webp)/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg?.*')) {
 
-                let url = imgElements[i].src.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg/, `${newImage}.jpg`);
+                let url = imgElements[i].src.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg/, `${newImage}.jpg`);
 
                 if (!url.match('.*stringtokillcache')) {
                     url += '?stringtokillcache'
@@ -121,9 +121,9 @@ if (typeof window.styleElement === 'undefined') { // shitty way to detect if scr
         for (let i = 0; i < backgroundImgElements.length; i++) {
             let styleAttribute = backgroundImgElements[i].getAttribute('style');
 
-            if (styleAttribute.match('.*https://i.ytimg.com/vi/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg?.*')) {
+            if (styleAttribute.match('.*https://i.ytimg.com/(vi|vi_webp)/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg?.*')) {
 
-                let newStyleAttribute = styleAttribute.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg/, `${newImage}.jpg`);
+                let newStyleAttribute = styleAttribute.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg/, `${newImage}.jpg`);
 
                 if (!newStyleAttribute.match('.*stringtokillcache.*')) {
                     // messes up existing query parameters that might be there, but that's ok.

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -104,9 +104,9 @@ if (typeof window.styleElement === 'undefined') { // shitty way to detect if scr
         let imgElements = document.getElementsByTagName('img');
 
         for (let i = 0; i < imgElements.length; i++) {
-            if (imgElements[i].src.match('https://i.ytimg.com/vi/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720).jpg?.*')) {
+            if (imgElements[i].src.match('https://i.ytimg.com/vi/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg?.*')) {
 
-                let url = imgElements[i].src.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720).jpg/, `${newImage}.jpg`);
+                let url = imgElements[i].src.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg/, `${newImage}.jpg`);
 
                 if (!url.match('.*stringtokillcache')) {
                     url += '?stringtokillcache'
@@ -121,9 +121,9 @@ if (typeof window.styleElement === 'undefined') { // shitty way to detect if scr
         for (let i = 0; i < backgroundImgElements.length; i++) {
             let styleAttribute = backgroundImgElements[i].getAttribute('style');
 
-            if (styleAttribute.match('.*https://i.ytimg.com/vi/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720).jpg?.*')) {
+            if (styleAttribute.match('.*https://i.ytimg.com/vi/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg?.*')) {
 
-                let newStyleAttribute = styleAttribute.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720).jpg/, `${newImage}.jpg`);
+                let newStyleAttribute = styleAttribute.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720|hq720_custom_[0-9]+).jpg/, `${newImage}.jpg`);
 
                 if (!newStyleAttribute.match('.*stringtokillcache.*')) {
                     // messes up existing query parameters that might be there, but that's ok.


### PR DESCRIPTION
Thumbnails were not updating if the image name was in the format hq720_custom_**[0-9]**.

These might be the format for [YouTube's new thumbnail A/B testing feature](https://www.youtube.com/watch?v=0veygaKzdjw).

For example, the "lamborghini vs shredder" thumbnail below was not updating. Its URL was: `https://i.ytimg.com/vi/vBpQ1SlfVtU/hq720_custom_3.jpg?sqp=...`

![before](https://github.com/pietervanheijningen/clickbait-remover-for-youtube/assets/12798735/8290db60-2e39-480f-8d07-29b1427bca69)


It can be fixed by adding the format to the regexes.

![after](https://github.com/pietervanheijningen/clickbait-remover-for-youtube/assets/12798735/5d0f641f-8dcb-4ef2-88b9-b37125178e29)


