### PR TITLE
Add quality setting choice

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -2,19 +2,23 @@ chrome.runtime.onInstalled.addListener(function ({reason}) {
     if (reason === 'install') {
         // default values
         chrome.storage.sync.set({
-            preferred_thumbnail_file: 'hq1',
+            preferred_thumbnail_file: '1',
+            preferred_thumbnail_resolution: 'hq',
             video_title_format: 'capitalize_first_letter'
         })
     }
 });
 
-chrome.storage.sync.get(['preferred_thumbnail_file'], function (storage) {
+chrome.storage.sync.get(['preferred_thumbnail_file', 'preferred_thumbnail_resolution'], function (storage) {
 
     if (storage.preferred_thumbnail_file === undefined) { // shitty fix
-        storage.preferred_thumbnail_file = "hq1"
+        storage.preferred_thumbnail_file = "1"
+    }
+    if (storage.preferred_thumbnail_resolution === undefined) { // shitty fix
+        storage.preferred_thumbnail_resolution = "hq"
     }
 
-    setupThumbnailRedirectListeners(storage.preferred_thumbnail_file);
+    setupThumbnailRedirectListeners(storage.preferred_thumbnail_file, storage.preferred_thumbnail_resolution);
 
     chrome.tabs.query({url: '*://www.youtube.com/*'}, function (tabs) {
         tabs.forEach(function (tab) {
@@ -27,7 +31,7 @@ chrome.storage.sync.get(['preferred_thumbnail_file'], function (storage) {
                 ,function () {
                     chrome.tabs.sendMessage(tab.id, {
                         'preferred_thumbnail_file': {
-                            newValue: storage.preferred_thumbnail_file
+                            newValue: `${storage.preferred_thumbnail_resolution}${storage.preferred_thumbnail_file}`
                         }
                     });
                 }
@@ -35,20 +39,26 @@ chrome.storage.sync.get(['preferred_thumbnail_file'], function (storage) {
         })
 
         chrome.storage.onChanged.addListener(function (changes) {
-            if (changes.preferred_thumbnail_file !== undefined) {
-                setupThumbnailRedirectListeners(changes.preferred_thumbnail_file.newValue);
-            }
-
-            chrome.tabs.query({url: '*://www.youtube.com/*'}, function (tabs) {
-                tabs.forEach(function (tab) {
-                    chrome.tabs.sendMessage(tab.id, changes);
-                })
+            chrome.storage.sync.get(['preferred_thumbnail_file', 'preferred_thumbnail_resolution'], function (storage) {
+                const preferred_thumbnail_file = changes.preferred_thumbnail_file?.newValue ?? storage.preferred_thumbnail_file ?? "1";
+                const preferred_thumbnail_resolution = changes.preferred_thumbnail_resolution?.newValue ?? storage.preferred_thumbnail_resolution ?? "1";
+                setupThumbnailRedirectListeners(preferred_thumbnail_file, preferred_thumbnail_resolution);
+                chrome.tabs.query({url: '*://www.youtube.com/*'}, function (tabs) {
+                    tabs.forEach(function (tab) {
+                        chrome.tabs.sendMessage(tab.id, {
+                            'preferred_thumbnail_file': {
+                                newValue: `${preferred_thumbnail_resolution}${preferred_thumbnail_file}`
+                            }
+                        });
+                    })
+                });
             });
+
         });
     });
 });
 
-function setupThumbnailRedirectListeners(preferredThumbnailFile) {
+function setupThumbnailRedirectListeners(preferredThumbnailFile, preferredThumbnailResolution) {
     if (preferredThumbnailFile === 'hqdefault') {
         chrome.declarativeNetRequest.updateDynamicRules({
             removeRuleIds: [1]
@@ -62,7 +72,7 @@ function setupThumbnailRedirectListeners(preferredThumbnailFile) {
                     "action": {
                         "type": "redirect",
                         "redirect": {
-                            "regexSubstitution": `https://i.ytimg.com/\\1/\\2/${preferredThumbnailFile}.jpg\\5`
+                            "regexSubstitution": `https://i.ytimg.com/\\1/\\2/${preferredThumbnailResolution}${preferredThumbnailFile}.jpg\\5`
                         }
                     },
                     "condition": {

--- a/js/options_popup.js
+++ b/js/options_popup.js
@@ -1,4 +1,4 @@
-let optionKeys = ['preferred_thumbnail_file', 'video_title_format'];
+let optionKeys = ['preferred_thumbnail_file', 'preferred_thumbnail_resolution', 'video_title_format'];
 
 chrome.storage.sync.get(optionKeys, function (storage) {
     optionKeys.forEach(function (optionKey) {

--- a/options_popup.html
+++ b/options_popup.html
@@ -151,24 +151,54 @@
             <div class="optionsContainer">
                 <div class="option-4">
                     <p data-localize="__MSG_startOfTheVideo__">Start of the video</p>
-                    <label for="preferred_thumbnail_file_hq1"></label>
-                    <input type="radio" value="hq1" id="preferred_thumbnail_file_hq1" name="preferred_thumbnail_file" />
+                    <label for="preferred_thumbnail_file_1"></label>
+                    <input type="radio" value="1" id="preferred_thumbnail_file_1" name="preferred_thumbnail_file" />
                 </div>
                 <div class="option-4">
                     <p data-localize="__MSG_middleOfTheVideo__">Middle of the video</p>
-                    <label for="preferred_thumbnail_file_hq2"></label>
-                    <input type="radio" value="hq2" id="preferred_thumbnail_file_hq2" name="preferred_thumbnail_file" />
+                    <label for="preferred_thumbnail_file_2"></label>
+                    <input type="radio" value="2" id="preferred_thumbnail_file_2" name="preferred_thumbnail_file" />
                 </div>
                 <div class="option-4">
                     <p data-localize="__MSG_endOfTheVideo__">End of the video</p>
-                    <label for="preferred_thumbnail_file_hq3"></label>
-                    <input type="radio" value="hq3" id="preferred_thumbnail_file_hq3" name="preferred_thumbnail_file" />
+                    <label for="preferred_thumbnail_file_3"></label>
+                    <input type="radio" value="3" id="preferred_thumbnail_file_3" name="preferred_thumbnail_file" />
                 </div>
                 <div class="option-4">
                     <p data-localize="__MSG_doNotModify__">Do not modify</p>
                     <label for="preferred_thumbnail_file_default"></label>
                     <input type="radio" value="hqdefault" id="preferred_thumbnail_file_default"
                         name="preferred_thumbnail_file" />
+                </div>
+            </div>
+
+            <h3 class="title" data-localize="__MSG_whichResolutionThumbnailImageToGrab__">Which resolution thumbnail image to grab:
+            </h3>
+            <div class="optionsContainer">
+                <div class="option-4">
+                    <p data-localize="__MSG_smallest90p__">Smallest (90p)</p>
+                    <label for="preferred_thumbnail_resolution_smallest"></label>
+                    <input type="radio" value="" id="preferred_thumbnail_resolution_smallest" name="preferred_thumbnail_resolution" />
+                </div>
+                <div class="option-4">
+                    <p data-localize="__MSG_small180p__">Small (180p)</p>
+                    <label for="preferred_thumbnail_resolution_mq"></label>
+                    <input type="radio" value="mq" id="preferred_thumbnail_resolution_mq" name="preferred_thumbnail_resolution" />
+                </div>
+                <div class="option-4">
+                    <p data-localize="__MSG_medium360p__">Medium (360p)</p>
+                    <label for="preferred_thumbnail_resolution_hq"></label>
+                    <input type="radio" value="hq" id="preferred_thumbnail_resolution_hq" name="preferred_thumbnail_resolution" />
+                </div>
+                <div class="option-4">
+                    <p data-localize="__MSG_high480p__">High (480p)</p>
+                    <label for="preferred_thumbnail_resolution_sd"></label>
+                    <input type="radio" value="sd" id="preferred_thumbnail_resolution_sd" name="preferred_thumbnail_resolution" />
+                </div>
+                <div class="option-4">
+                    <p data-localize="__MSG_max720p__">Max (720p)</p>
+                    <label for="preferred_thumbnail_resolution_maxres"></label>
+                    <input type="radio" value="maxres" id="preferred_thumbnail_resolution_maxres" name="preferred_thumbnail_resolution" />
                 </div>
             </div>
 


### PR DESCRIPTION
This is just a rough pass over a patch I want. Opening a PR to share.

Basically anywhere the code has `preferred_thumbnail_file` there is now an additional `preferred_thumbnail_resolution`. The available resolutions are all the ones I know of: 90p, 180p, 360p, 480p, and 720p. The previous default of `hq` is only the 360p screenshot, which on my display for the YouTube homepage looks terrible.

Most of the work actually went into getting the `onChanged` handler for the settings to work well. I want to have another pass at optimising this before I would consider this PR ready for merge. I would then also want to make youtube.js support more than 1 settings change. It currently only has one possible cache killer. This made testing a little annoying.

Another thing that made testing annoying was that the firefox_manifest.json did not work for me at all. I had to add `declarativeNetRequest` to get anywhere with it. I need to take another pass at that one to get the extension to actually start running its latest code in Firefox again.

@pietervanheijningen would you be interested in merging a PR introducing the quality picker as well as getting Firefox updated to run version 9 of the extension? Or am I better off maintaining a fork for myself and AMO?