### PR TITLE
Add support for i9 subdomain

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -66,12 +66,14 @@ function setupThumbnailRedirectListeners(preferredThumbnailFile) {
                         }
                     },
                     "condition": {
-                        "regexFilter": "^https://i.ytimg.com/(vi|vi_webp)/(.*)/(default|hqdefault|mqdefault|sddefault|hq720)(_custom_[0-9]+)?.jpg(.*)",
+                        "regexFilter": "^https://i9?.ytimg.com/(vi|vi_webp)/(.*)/(default|hqdefault|mqdefault|sddefault|hq720)(_custom_[0-9]+)?.jpg(.*)",
                         "resourceTypes": [
                             "image"
                         ]
                     }
                 }
+                
+
             ],
             removeRuleIds: [1]
         })

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -104,7 +104,7 @@ if (typeof window.styleElement === 'undefined') { // shitty way to detect if scr
         let imgElements = document.getElementsByTagName('img');
 
         for (let i = 0; i < imgElements.length; i++) {
-            if (imgElements[i].src.match('https://i.ytimg.com/(vi|vi_webp)/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg?.*')) {
+            if (imgElements[i].src.match('https://i9?.ytimg.com/(vi|vi_webp)/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg?.*')) {
 
                 let url = imgElements[i].src.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg/, `${newImage}.jpg`);
 
@@ -121,7 +121,7 @@ if (typeof window.styleElement === 'undefined') { // shitty way to detect if scr
         for (let i = 0; i < backgroundImgElements.length; i++) {
             let styleAttribute = backgroundImgElements[i].getAttribute('style');
 
-            if (styleAttribute.match('.*https://i.ytimg.com/(vi|vi_webp)/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg?.*')) {
+            if (styleAttribute.match('.*https://i9?.ytimg.com/(vi|vi_webp)/.*/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg?.*')) {
 
                 let newStyleAttribute = styleAttribute.replace(/(hq1|hq2|hq3|hqdefault|mqdefault|hq720)(_custom_[0-9]+)?.jpg/, `${newImage}.jpg`);
 

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
   "host_permissions": [
     "*://www.youtube.com/*",
     "*://m.youtube.com/*",
-    "*://i.ytimg.com/*"
+    "*://i.ytimg.com/*",
+    "*://i9.ytimg.com/*"
   ]
 }


### PR DESCRIPTION
Some images are hosted on i9.ytimg.com instead of i.ytimg.com. This adds support for that subdomain as well.

Original image:
https://i9.ytimg.com/vi/MBkxJCM_SoE/hq720_custom_3.jpg?sqp=CJTh0LYG-oaymwEcCNAFEJQDSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLC7b82CuIwWfn5NDWeYOSXx9sXOuQ

New image:
https://i.ytimg.com/vi/MBkxJCM_SoE/hq1.jpg?sqp=CJTh0LYG-oaymwEcCNAFEJQDSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLC7b82CuIwWfn5NDWeYOSXx9sXOuQ